### PR TITLE
Add a zone ID output to allow users to create Alias records

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,10 @@ output "vault_lb_dns" {
   value = "${element(concat(aws_lb.vault.*.dns_name, list("")), 0)}" # TODO: Workaround for issue #11210
 }
 
+output "vault_lb_zone_id" {
+  value = "${element(concat(aws_lb.vault.*.zone_id, list("")), 0)}" # TODO: Workaround for issue #11210
+}
+
 output "vault_lb_arn" {
   value = "${element(concat(aws_lb.vault.*.arn, list("")), 0)}" # TODO: Workaround for issue #11210
 }


### PR DESCRIPTION
Without access to the Vault load balancer's zone ID, it is not possible to create Alias records (if one wished to do so).